### PR TITLE
Update build.gradle for mavenCentral compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,6 +29,6 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     testImplementation 'junit:junit:4.12'
     implementation 'com.facebook.react:react-native:+'
-    implementation 'com.facebook.fresco:fresco:2.0.0'
-    implementation 'me.relex:photodraweeview:2.0.0'
+    implementation 'com.facebook.fresco:fresco:2.1.0'
+    implementation 'me.relex:photodraweeview:2.1.0'
 }


### PR DESCRIPTION
When upgrading to a newer version of react native and removing the jCenter repo, the photodraweeview dependency needs to be updated to come from mavenCentral. This change will allow this package to be compatible with newer versions of react native that no longer include the jCenter repo.